### PR TITLE
feat: move singRecorderObject and pitchModelExecutorObject to constructor

### DIFF
--- a/app/src/main/java/com/george/pitch_estimator/di/SingingFragmentModule.kt
+++ b/app/src/main/java/com/george/pitch_estimator/di/SingingFragmentModule.kt
@@ -12,6 +12,6 @@ val singingFragmentModule = module {
     single { PitchModelExecutor(get(), getKoin().getProperty("koinUseGpu")!!) }
 
     viewModel {
-        SingingFragmentViewModel(get())
+        SingingFragmentViewModel(get(), get(), get())
     }
 }

--- a/app/src/main/java/com/george/pitch_estimator/singingFragment/SingingFragment.kt
+++ b/app/src/main/java/com/george/pitch_estimator/singingFragment/SingingFragment.kt
@@ -47,7 +47,6 @@ class SingingFragment : Fragment() {
         getKoin().setProperty("koinUseGpu", false)
         singRecorder = get()
         pitchModelExecutor = get()
-        viewModel.setSingRecorderModule(singRecorder, pitchModelExecutor)
 
         binding.buttonForSinging.setOnClickListener {
 

--- a/app/src/main/java/com/george/pitch_estimator/singingFragment/SingingFragmentViewModel.kt
+++ b/app/src/main/java/com/george/pitch_estimator/singingFragment/SingingFragmentViewModel.kt
@@ -15,20 +15,13 @@ import java.io.IOException
 import java.io.RandomAccessFile
 import kotlin.experimental.and
 
-class SingingFragmentViewModel(application: Application) : AndroidViewModel(application) {
-
-    lateinit var singRecorderObject: SingRecorder
-    lateinit var pitchModelExecutorObject: PitchModelExecutor
+class SingingFragmentViewModel(
+        application: Application,
+        private val singRecorderObject: SingRecorder,
+        private val pitchModelExecutorObject: PitchModelExecutor
+) : AndroidViewModel(application) {
 
     var _singingRunning = false
-
-    init {
-    }
-
-    fun setSingRecorderModule(singRecorder: SingRecorder, pitchModelExecutor: PitchModelExecutor) {
-        singRecorderObject = singRecorder
-        pitchModelExecutorObject = pitchModelExecutor
-    }
 
     fun startSinging() {
 


### PR DESCRIPTION
As discussed, moved the dependencies to the constructor for proper DI (SL)
However, faced a crash, inside `SingRecorder`, I don't think it's related to the DI change, however, if you feel it's because of that, let me know I'll try and fix that. Please find the stack-trace as below.
```2020-07-20 09:07:25.877 27572-27572/com.george.pitch_estimator E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.george.pitch_estimator, PID: 27572
    kotlin.KotlinNullPointerException
        at com.george.pitch_estimator.SingRecorder.writeWav(SingRecorder.kt:552)
        at com.george.pitch_estimator.singingFragment.SingingFragmentViewModel$doInference$2.invokeSuspend(SingingFragmentViewModel.kt:53)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:241)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:740)
```